### PR TITLE
Synchronize timeout harness child startup

### DIFF
--- a/spec/system_timeout_spec.rb
+++ b/spec/system_timeout_spec.rb
@@ -93,7 +93,7 @@ describe 'test harness subprocess timeouts' do
           ready_output: 'child-ready',
           startup_timeout: 2
         )
-      end.to raise_error(SystemCommandError, /Command timed out/)
+      end.to raise_error(SystemCommandError, /Command timed out/) { |error| expect(error.timeout).to eq(0.25) }
 
       child_pid = Integer(File.read(child_pid_file))
       wait_until_stopped(child_pid)

--- a/spec/system_timeout_spec.rb
+++ b/spec/system_timeout_spec.rb
@@ -76,13 +76,23 @@ describe 'test harness subprocess timeouts' do
     Dir.mktmpdir('dab-timeout-child') do |directory|
       child_pid_file = File.join(directory, 'child.pid')
       script = <<~RUBY
+        # Keep startup slower than the execution timeout to make the handshake
+        # necessary instead of relying on the runner scheduling the child.
+        sleep 0.35
         child = Process.spawn(#{ruby.dump}, '-e', 'sleep 60')
         File.write(ARGV.fetch(0), child.to_s)
+        STDOUT.write('child-ready')
+        STDOUT.flush
         sleep 60
       RUBY
 
       expect do
-        qsystem(ruby_command(script, child_pid_file), timeout: 0.25)
+        qsystem(
+          ruby_command(script, child_pid_file),
+          timeout: 0.25,
+          ready_output: 'child-ready',
+          startup_timeout: 2
+        )
       end.to raise_error(SystemCommandError, /Command timed out/)
 
       child_pid = Integer(File.read(child_pid_file))

--- a/src/shared/system.rb
+++ b/src/shared/system.rb
@@ -153,14 +153,22 @@ private
   end
 end
 
-def system_with_progress(cmd, input: nil, input_file: nil, show_stderr: true, show_stdout: true, binmode: false, timeout: nil)
+def system_with_progress(cmd, input: nil, input_file: nil, show_stderr: true, show_stdout: true, binmode: false,
+                         timeout: nil, ready_output: nil, startup_timeout: nil)
   command = SystemRunCommand.new(cmd)
   command.open_process!(input: input, input_file: input_file, binmode: binmode)
   fdlist = command.streams
   stdout = ''
   stderr = ''
   timeout = Float(timeout) if timeout
-  deadline = monotonic_time + timeout if timeout
+  if ready_output
+    raise ArgumentError.new('startup_timeout is required with ready_output') unless startup_timeout
+
+    startup_timeout = Float(startup_timeout)
+  end
+  ready = ready_output.nil?
+  timeout_limit = ready ? timeout : startup_timeout
+  deadline = monotonic_time + timeout_limit if timeout_limit
   timed_out = false
   while true
     fdlist.reject!(&:closed?)
@@ -169,6 +177,7 @@ def system_with_progress(cmd, input: nil, input_file: nil, show_stderr: true, sh
     if deadline && monotonic_time >= deadline && !command.finished?
       command.terminate!
       timed_out = true
+      timeout = timeout_limit
       deadline = nil
       next
     end
@@ -192,6 +201,11 @@ def system_with_progress(cmd, input: nil, input_file: nil, show_stderr: true, sh
         else
           DabTestOutput.emit(line, stream: :stdout, display: :stderr) if show_stdout
           stdout += line
+        end
+        if !ready && stdout.include?(ready_output)
+          ready = true
+          timeout_limit = timeout
+          deadline = monotonic_time + timeout if timeout
         end
         data = true
       end
@@ -224,7 +238,8 @@ def psystem(cmd)
   end
 end
 
-def qsystem(cmd, input: nil, input_file: nil, output_file: nil, timeout: nil, error_file: nil, binmode: false)
+def qsystem(cmd, input: nil, input_file: nil, output_file: nil, timeout: nil, error_file: nil, binmode: false,
+            ready_output: nil, startup_timeout: nil)
   DabTestOutput.emit(' >> '.yellow)
   DabTestOutput.emit("timeout #{timeout} ".white) if timeout
   DabTestOutput.emit(cmd.yellow)
@@ -238,7 +253,9 @@ def qsystem(cmd, input: nil, input_file: nil, output_file: nil, timeout: nil, er
     show_stdout: !output_file,
     show_stderr: !error_file,
     binmode: binmode,
-    timeout: timeout
+    timeout: timeout,
+    ready_output: ready_output,
+    startup_timeout: startup_timeout
   )
   DabTestOutput.record_command(
     cmd,

--- a/src/shared/system.rb
+++ b/src/shared/system.rb
@@ -123,6 +123,8 @@ private
     true
   rescue Errno::ESRCH
     false
+  rescue Errno::EPERM
+    true
   end
 
   def wait_for_process_group(seconds)

--- a/src/shared/system.rb
+++ b/src/shared/system.rb
@@ -193,9 +193,9 @@ def system_with_progress(cmd, input: nil, input_file: nil, show_stderr: true, sh
     selected = IO.select(fdlist, nil, nil, wait_time)
     next unless selected
 
-    ready = selected[0]
+    ready_fds = selected[0]
     data = false
-    ready.each do |fd|
+    ready_fds.each do |fd|
       command.try_update(fd) do |line, is_stderr|
         if is_stderr
           DabTestOutput.emit(line, stream: :stderr, display: :stderr) if show_stderr


### PR DESCRIPTION
## Summary

Fix the pre-existing macOS timeout-spec race where the 0.25-second timeout could fire before the child PID file was written.

The harness now supports an explicit stdout readiness marker with a separately bounded startup timeout. The process timeout begins only after the marker is observed; normal Unix process-group TERM/KILL escalation, Windows task-tree handling, status, diagnostics, and bounded execution remain unchanged. The regression deliberately delays startup beyond 0.25 seconds and proves the child PID before exercising the timeout.

## Root cause

`system_with_progress` started the execution deadline immediately after spawning the command. `spec/system_timeout_spec.rb` then assumed the asynchronously spawned child had already written its PID file before that deadline. On macOS CI, startup scheduling exceeded 0.25 seconds, producing `Errno::ENOENT` after the expected timeout.

## Scope

- Base: `8c08c3412c1300503528f5f37e5e0741ad677c0d`
- Root `VERSION`: remains `0.0.19`
- Changed paths: `src/shared/system.rb`, `spec/system_timeout_spec.rb`
- No generated documentation, production timeout values, bytecode-loader code, PR #31, or Wiki changes

## Validation

- Focused timeout spec: 8 randomized seeds, including 23759, 43603, and 49192
- Focused timeout plus legacy smoke specs: 21 examples, 0 failures
- Changed-file RuboCop and `git diff --check`: passed
- Disposable `PREMAKE=/tmp/dablang-tools/premake5 bundle exec ruby script/complete_gate.rb`: passed; 221 examples, 0 failures, 16 pending
- Standalone pre-build RSpec was not treated as a gate because the checkout lacked native `bin/cvm`, `bin/cdumpcov`, and `bin/cdisasm`; the disposable complete gate built them and passed

Ready for macOS CI verification.