### PR TITLE
Require codex-codex for every subwork

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,9 @@ path. Preserve the distinction in code, documentation, reviews, and planning.
 - Use one clean isolated worktree and one `tomasz/` branch per SUBWORK. Never
   modify the shared launch checkout, another agent's worktree, or an unrelated
   dirty branch.
+- Run every SUBWORK on `codex-codex`, the designated SUBWORK execution host,
+  regardless of where the MASTER THREAD runs. If that host is unavailable,
+  report a blocker instead of running the SUBWORK on another host.
 - Use the `ship-feature-pr` workflow for implementation PRs and the GitHub
   workflow for live PR state when those skills are available. Local confidence
   never replaces exact-head GitHub evidence.


### PR DESCRIPTION
## Summary

- require every SUBWORK to execute on the codex-codex host
- keep the rule independent of the host running the MASTER THREAD
- require a blocker report instead of silently running SUBWORK elsewhere

## Validation

- git diff --check
- PREMAKE=/tmp/dablang-premake-beta8/premake5 ruby script/toolchain_preflight.rb

This follow-up is based on the merged AGENTS.md guidance from #53 and changes no product behavior or VERSION.