### PR TITLE
Clarify SUBWORK task isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,9 @@ blocks the finish line, report `review-blocked`, `dependency-blocked`, or
 One MASTER THREAD owns the Scenario B sequence, cross-cutting decisions, and
 the canonical planning view. A SUBWORK has one bounded deliverable, one branch
 or no branch for read-only work, and no authority to broaden the charter.
+Every SUBWORK is a new, durable Codex chat created on the designated
+`codex-codex` Codex host. A local subagent of the MASTER THREAD is not a
+SUBWORK and must not be used to execute one.
 
 Before starting a SUBWORK, the MASTER THREAD records it in the **TABELKA**
 (the compact coordination table in the Scenario B Wiki work log) with: ID,


### PR DESCRIPTION
## Summary

- define every SUBWORK as a new, durable Codex chat on the designated `codex-codex` host
- state explicitly that a local MASTER THREAD subagent is not a SUBWORK and cannot execute one

## Why

This removes ambiguity between internal local-agent delegation and the durable, user-visible, host-isolated task model required by the Scenario B workflow.

## Validation

- `git diff --check master...HEAD`
- manual Markdown structure review
- clean isolated worktree before push
- no generated files changed

The local supported-toolchain preflight was attempted but is not authoritative on this launch host: it reports unsupported `macos-arm64` and Bundler 4.0.17 instead of the required 2.7.2. This documentation-only change does not advance `VERSION`.
