### PR TITLE
Skip CI for Markdown-only pull requests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: ci-${{ github.event.pull_request.number }}

--- a/lib/dab/toolchain_preflight.rb
+++ b/lib/dab/toolchain_preflight.rb
@@ -373,9 +373,15 @@ module Dab
 
       def check_workflow_guards(errors, workflow_text, workflow, jobs)
         trigger_block = workflow_text[/^on:\n(?:[ \t].*(?:\n|\z))*/]
-        expected_trigger_block = "on:\n  pull_request:\n    branches: [master]\n"
+        expected_trigger_block = <<~YAML
+          on:
+            pull_request:
+              branches: [master]
+              paths-ignore:
+                - '**.md'
+        YAML
         unless trigger_block == expected_trigger_block
-          errors << 'CI trigger drifted; keep the workflow pull-request-only for master'
+          errors << 'CI trigger drifted; keep the master pull-request workflow disabled only for all-Markdown changes'
         end
 
         permissions = workflow.fetch('permissions', {})

--- a/spec/toolchain_contract_spec.rb
+++ b/spec/toolchain_contract_spec.rb
@@ -27,6 +27,12 @@ describe Dab::ToolchainPreflight::RepositoryContract do
     end
   end
 
+  def workflow_runs_for?(changed_paths, ignored_patterns)
+    changed_paths.any? do |path|
+      ignored_patterns.none? { |pattern| File.fnmatch?(pattern, path, File::FNM_DOTMATCH) }
+    end
+  end
+
   it 'keeps five normal runs, two independent sanitizer runs, and the public-site job consistent' do
     with_contract_repository(project_root) do |root, contract|
       errors = described_class.new(root: root, contract: contract).errors
@@ -126,8 +132,18 @@ describe Dab::ToolchainPreflight::RepositoryContract do
 
       errors = described_class.new(root: root, contract: contract).errors
 
-      expect(errors).to include('CI trigger drifted; keep the workflow pull-request-only for master')
+      expect(errors).to include(
+        'CI trigger drifted; keep the master pull-request workflow disabled only for all-Markdown changes'
+      )
     end
+  end
+
+  it 'starts CI unless every changed path ends in .md' do
+    ignored_patterns = ['**.md']
+
+    expect(workflow_runs_for?(%w[README.md docs/building.md], ignored_patterns)).to be(false)
+    expect(workflow_runs_for?(%w[README.md src/compiler/compiler.rb], ignored_patterns)).to be(true)
+    expect(workflow_runs_for?(%w[.github/workflows/ruby.yml], ignored_patterns)).to be(true)
   end
 
   it 'detects Rake tool-selection drift' do


### PR DESCRIPTION
## Summary

- skip the CI workflow only when every path in the complete pull-request diff ends in `.md`
- retain the full existing matrix for every mixed or non-Markdown change
- lock the trigger and representative all-Markdown, mixed, and workflow-file controls in the existing toolchain contract

## Behavior

GitHub evaluates the `pull_request.paths-ignore` filter across the complete pull-request change set. The single `**.md` pattern suppresses this workflow only when every changed path matches. Any unmatched path starts the unchanged full matrix. This PR changes `.github/workflows/ruby.yml`, so its own CI must start normally.

Manual Markdown link and structure review remains required for Markdown-only pull requests.

## Validation

- `bundle exec rspec spec/toolchain_contract_spec.rb` — 15 examples, 0 failures
- `actionlint .github/workflows/ruby.yml`
- `bundle exec rubocop --cache false lib/dab/toolchain_preflight.rb spec/toolchain_contract_spec.rb`
- `ruby -c lib/dab/toolchain_preflight.rb`
- `ruby -c spec/toolchain_contract_spec.rb`
- `git diff --check`
- all-Markdown negative control: `README.md` + `docs/building.md` does not start CI
- mixed positive control: `README.md` + `src/compiler/compiler.rb` starts CI
- non-Markdown positive control: `.github/workflows/ruby.yml` starts CI

A broad bare `bundle exec rspec` reached 411 examples but had 63 expected fresh-worktree failures because `bin/cvm`, `bin/cdisasm`, and `bin/cdumpcov` are absent; the authoritative PR matrix builds those native tools before running the complete gate.

## Governance and risk

- exact base: `40f610c0115bf66391fddffe23d1ef73966a9682`
- root `VERSION` remains `0.0.40`
- generated documentation is unchanged
- live `master` is currently unprotected and reports required status-check enforcement off with no contexts, so an intentionally absent Markdown-only workflow does not deadlock mergeability
- if these jobs become required checks later, GitHub documents that a workflow skipped by path filtering can remain pending and block merge; repository protection must be reassessed before requiring these contexts
- no compiler, runtime, generated documentation, Wiki, repository-setting, or macOS EINTR-flake change is included
