### PR TITLE
Handle interrupted subprocess output reads

### DIFF
--- a/spec/system_timeout_spec.rb
+++ b/spec/system_timeout_spec.rb
@@ -7,6 +7,78 @@ require 'tmpdir'
 
 require_relative '../src/shared/system'
 
+module SystemTimeoutSpecSupport
+  class SequencedRead
+    attr_reader :read_count
+
+    def initialize(*outcomes)
+      @outcomes = outcomes
+      @closed = false
+      @read_count = 0
+    end
+
+    def read_nonblock(_length)
+      @read_count += 1
+      outcome = @outcomes.shift
+      raise outcome if outcome.is_a?(Exception)
+      raise EOFError if outcome == :eof
+
+      outcome
+    end
+
+    def close
+      @closed = true
+    end
+
+    def closed?
+      @closed
+    end
+  end
+
+  class FakeRunCommand < SystemRunCommand
+    attr_reader :terminate_count
+
+    def initialize(stdout:, stderr:, finished:, exit_code: 0)
+      super('ignored')
+      @stdout = stdout
+      @stderr = stderr
+      @finished = finished
+      @exit_code = exit_code
+      @terminate_count = 0
+      @child_alive = !finished
+      @wait_thread_alive = !finished
+    end
+
+    def open_process!(**)
+      nil
+    end
+
+    def finished?
+      @finished
+    end
+
+    def terminate!
+      @terminate_count += 1
+      streams.each(&:close)
+      @finished = true
+      @child_alive = false
+      @wait_thread_alive = false
+    end
+
+    def wait_for_exit(_seconds = nil)
+      @finished
+    end
+
+    def child_alive?
+      @child_alive
+    end
+
+    def wait_thread_alive?
+      @wait_thread_alive
+    end
+  end
+end
+
 describe 'test harness subprocess timeouts' do
   let(:ruby) { RbConfig.ruby }
 
@@ -29,6 +101,95 @@ describe 'test harness subprocess timeouts' do
   def wait_until_stopped(pid)
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
     sleep 0.01 while process_running?(pid) && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+  end
+
+  def select_open_streams
+    allow(IO).to receive(:select) do |streams, *_arguments|
+      [streams.reject(&:closed?), [], []]
+    end
+  end
+
+  it 'reports data, transient reads, and EOF as distinct update outcomes' do
+    stdout = SystemTimeoutSpecSupport::SequencedRead.new('before', Errno::EINTR.new, 'after', :eof)
+    stderr = SystemTimeoutSpecSupport::SequencedRead.new(:eof)
+    command = SystemTimeoutSpecSupport::FakeRunCommand.new(stdout: stdout, stderr: stderr, finished: true)
+    output = ''
+
+    expect(command.try_update(stdout) { |data, _| output += data }).to eq(:data)
+    expect(command.try_update(stdout) { |data, _| output += data }).to eq(:repoll)
+    expect(command.try_update(stdout) { |data, _| output += data }).to eq(:data)
+    expect(command.try_update(stdout) { |data, _| output += data }).to eq(:eof)
+    expect(output).to eq('beforeafter')
+  end
+
+  it 're-polls after EINTR even when the child has exited, then drains both streams' do
+    stdout = SystemTimeoutSpecSupport::SequencedRead.new('before-', Errno::EINTR.new, 'after', :eof)
+    stderr = SystemTimeoutSpecSupport::SequencedRead.new('error', :eof)
+    command = SystemTimeoutSpecSupport::FakeRunCommand.new(stdout: stdout, stderr: stderr, finished: true)
+    select_open_streams
+    allow(SystemRunCommand).to receive(:new).and_return(command)
+
+    result = system_with_progress('ignored', show_stdout: false, show_stderr: false)
+
+    expect(result).to include(exit_code: 0, stdout: 'before-after', stderr: 'error', timed_out: false)
+    expect(IO).to have_received(:select).exactly(4).times
+  end
+
+  it 're-polls after repeated EINTR, preserves the deadline, and terminates once' do
+    stdout = SystemTimeoutSpecSupport::SequencedRead.new(Errno::EINTR.new, Errno::EINTR.new)
+    stderr = SystemTimeoutSpecSupport::SequencedRead.new(:eof)
+    command = SystemTimeoutSpecSupport::FakeRunCommand.new(
+      stdout: stdout,
+      stderr: stderr,
+      finished: false,
+      exit_code: 15
+    )
+    monotonic_times = [0.0, 0.0, 0.0, 0.4, 0.4, 1.0]
+    wait_times = []
+    allow(self).to receive(:monotonic_time) { monotonic_times.shift }
+    allow(IO).to receive(:select) do |streams, _write, _error, wait_time|
+      wait_times << wait_time
+      [[streams.first], [], []]
+    end
+    allow(SystemRunCommand).to receive(:new).and_return(command)
+
+    result = system_with_progress('ignored', timeout: 1, show_stdout: false, show_stderr: false)
+
+    expect(result).to include(exit_code: 124, stdout: '', stderr: '', timed_out: true, timeout: 1.0)
+    expect(wait_times).to eq([1.0, 0.6])
+    expect(command.terminate_count).to eq(1)
+    expect(command).to be_finished
+    expect(command).not_to be_child_alive
+    expect(command).not_to be_wait_thread_alive
+    expect(command.streams).to all(be_closed)
+    expect(monotonic_times).to be_empty
+  end
+
+  it 're-polls IO::WaitReadable through IO.select instead of retrying the read in place' do
+    stdout = SystemTimeoutSpecSupport::SequencedRead.new(IO::EAGAINWaitReadable.new, 'completed', :eof)
+    stderr = SystemTimeoutSpecSupport::SequencedRead.new(:eof)
+    command = SystemTimeoutSpecSupport::FakeRunCommand.new(stdout: stdout, stderr: stderr, finished: true)
+    select_open_streams
+    allow(SystemRunCommand).to receive(:new).and_return(command)
+
+    result = system_with_progress('ignored', show_stdout: false, show_stderr: false)
+
+    expect(result).to include(exit_code: 0, stdout: 'completed', stderr: '', timed_out: false)
+    expect(IO).to have_received(:select).exactly(3).times
+    expect(stdout.read_count).to eq(3)
+  end
+
+  [Interrupt.new, SignalException.new('TERM'), Errno::EIO.new].each do |failure|
+    it "propagates #{failure.class} from subprocess output reads" do
+      stdout = SystemTimeoutSpecSupport::SequencedRead.new(failure)
+      command = SystemTimeoutSpecSupport::FakeRunCommand.new(
+        stdout: stdout,
+        stderr: SystemTimeoutSpecSupport::SequencedRead.new(:eof),
+        finished: true
+      )
+
+      expect { command.try_update(stdout) }.to raise_error(failure.class)
+    end
   end
 
   it 'allows a declared-timeout command to complete before its deadline' do

--- a/src/shared/system.rb
+++ b/src/shared/system.rb
@@ -50,15 +50,16 @@ class SystemRunCommand
   end
 
   def try_update(fd)
-    return unless streams.include?(fd)
+    return :ignored unless streams.include?(fd)
 
     data = fd.read_nonblock(1024)
     yield(data, fd == @stderr) unless data.empty?
-  rescue IO::WaitReadable
-    nil
+    :data
+  rescue IO::WaitReadable, Errno::EINTR
+    :repoll
   rescue EOFError
     fd.close
-    nil
+    :eof
   end
 
   def finished?
@@ -195,8 +196,9 @@ def system_with_progress(cmd, input: nil, input_file: nil, show_stderr: true, sh
 
     ready_fds = selected[0]
     data = false
+    repoll = false
     ready_fds.each do |fd|
-      command.try_update(fd) do |line, is_stderr|
+      update = command.try_update(fd) do |line, is_stderr|
         if is_stderr
           DabTestOutput.emit(line, stream: :stderr, display: :stderr) if show_stderr
           stderr += line
@@ -209,10 +211,11 @@ def system_with_progress(cmd, input: nil, input_file: nil, show_stderr: true, sh
           timeout_limit = timeout
           deadline = monotonic_time + timeout if timeout
         end
-        data = true
       end
+      data = true if update == :data
+      repoll = true if update == :repoll
     end
-    next if data
+    next if data || repoll
     break if command.finished?
   end
   {


### PR DESCRIPTION
## Summary

- return explicit data, repoll, and EOF outcomes from subprocess output reads
- treat only `IO::WaitReadable` and `Errno::EINTR` as transient and return to the outer polling loop
- preserve the original monotonic deadline, child cleanup, output draining, and unrelated exception propagation

## Root cause

PR #56's macOS Ruby 3.3.12 job propagated a legitimate `Errno::EINTR` from `fd.read_nonblock(1024)` before `qsystem` could record the child status or deterministically drain and clean up the child. The exact signal remains unknown; a short-lived-child `SIGCHLD` race is the leading inference, not a proven fact. The matching signature occurred once in 116 macOS attempts (0.86%), with latent POSIX exposure despite no observed Linux example.

This change deliberately leaves `IO.select` unchanged and does not rescue `Interrupt`, `SignalException`, or non-EINTR `SystemCallError` values.

## Base and scope

- exact base: `4a9e6d5e04fbefdc53efa8850bc330090e31606c`
- root `VERSION`: unchanged at `0.0.40`
- changed paths: `src/shared/system.rb`, `spec/system_timeout_spec.rb`
- no compiler, assembler, VM/product runtime, generated documentation, Wiki/TABELKA, workflow, runner-image, or R35 change

## Validation

- focused timeout specs: 11 examples, 0 failures
- full RSpec: 418 examples, 0 failures, 16 pending
- authoritative `ruby script/complete_gate.rb`: passed
- inherited fixtures: minitest 5, Dab 240, Modern source 22, format 31, VM 36, disassembly 10, assembly 102, dumpcov 2, coverage 1, debug 7, multidab 12, decompile 24
- changed-file RuboCop: no offenses
- Ruby syntax checks: passed
- `git diff --check`: passed
- generated documentation and root `VERSION`: clean

Local validation used the pinned Premake 5.0.0-beta8. The sandbox required a temporary writable Bundler user directory and a temporary external no-op `xclip` executable to prevent environment-only warnings from contaminating byte-for-byte stderr contracts; neither is part of this branch.
