### PR TITLE
Document dynamic MASTER task titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,38 @@ Every SUBWORK is a new, durable Codex chat created on the designated
 `codex-codex` Codex host. A local subagent of the MASTER THREAD is not a
 SUBWORK and must not be used to execute one.
 
+### Dynamic MASTER task title
+
+Only the MASTER THREAD renames the MASTER Codex task. Its title consists of an
+optional state prefix, the stable base title `🌍 DABLANG`, and one very short
+bracketed descriptor for each current worker, for example
+`⏳ 🌍 DABLANG [New CLI options]`. Once a worker has a pull request, include its
+number in that descriptor, for example `[#1234 New CLI options]`.
+
+Choose the single prefix for the highest-priority global MASTER state:
+
+1. Use the highest applicable attention state: `‼️` for a critical, safety,
+   data-loss, or work-invalidating intervention; `❗️` for a concrete blocker or
+   error needing owner action; `⁉️` for an urgent or ambiguous owner decision;
+   or `❓` for an ordinary owner decision.
+2. Otherwise use `⏳` while one or more workers are active.
+3. Otherwise use `✅` when work finished correctly and MASTER is waiting for
+   owner direction.
+4. Otherwise use no prefix when idle.
+
+When workers have mixed states, `attention > active > completed-waiting > idle`
+still selects one global prefix, while the descriptors continue to list every
+current worker. Update the title whenever a worker is dispatched or claimed,
+becomes blocked or requires a decision, publishes a pull request, completes,
+is resolved, is merged or closed, or the worker set otherwise changes. Remove
+stale worker descriptors immediately; keep descriptions extremely short and
+omit SHAs, branch names, task IDs, and verbose status.
+
+A SUBWORK reports state and pull-request transitions through its callbacks; it
+never renames the MASTER task itself. The dynamic title is transient
+coordination metadata and never replaces TABELKA, callbacks, tests, decision
+records, or GitHub evidence.
+
 Before starting a SUBWORK, the MASTER THREAD records it in the **TABELKA**
 (the compact coordination table in the Scenario B Wiki work log) with: ID,
 stage/gate, objective, repository area, prerequisite decision/evidence,


### PR DESCRIPTION
## Summary

- define the stable MASTER task title `🌍 DABLANG`
- add global attention, active, completed-waiting, and idle prefix precedence
- require concise worker descriptors and the `[#NN Short description]` PR form
- define update triggers, stale-descriptor removal, and MASTER-only rename ownership

## Scope

This is a governance-only Markdown change based on exact master `9bcd2e4019e637720b4ac478210ec1575055bc6a`.

The sole changed path is `AGENTS.md` with 32 insertions and no deletions. Root VERSION remains `0.0.45`; generated documentation and all product/runtime paths are unchanged.

The rule preserves the existing requirement that every SUBWORK is a new durable task on `codex-codex`, never a local subagent. Dynamic titles remain transient coordination metadata and do not replace TABELKA, callbacks, tests, decisions, or GitHub evidence.

## Validation

- exact live compare: one commit, one path, zero commits behind
- manual Markdown heading, list, inline-code, emoji, and surrounding-flow review
- `git diff --check origin/master..HEAD`
- clean synchronized worker and unchanged VERSION/generated paths

The checked-in pull-request workflow intentionally omits CI for an all-Markdown change set. Manual structure review and exact-head review remain required.
