### PR TITLE
Rename Modern fixture output section

### DIFF
--- a/spec/modern_source_fixture_spec.rb
+++ b/spec/modern_source_fixture_spec.rb
@@ -94,12 +94,14 @@ describe DabModernSourceFixture do
       next unless basename.end_with?('.dabmtest')
 
       path = File.join(fixture_directory, basename)
-      path if File.binread(path).include?("## EXPECTED APPLICATION STDOUT\n")
+      transport_content = File.binread(path).gsub("\r\n", "\n")
+      path if transport_content.include?("## EXPECTED APPLICATION STDOUT\n")
     end.sort
 
     expect(paths.map { |path| File.basename(path) }).to eq(expected_basenames)
     paths.each do |path|
-      headers = File.binread(path).scan(/^## ([A-Z]+(?: [A-Z]+)*)\n/).flatten
+      transport_content = File.binread(path).gsub("\r\n", "\n")
+      headers = transport_content.scan(/^## ([A-Z]+(?: [A-Z]+)*)\n/).flatten
       expect(headers.first(2)).to eq(['SOURCE', 'EXPECTED APPLICATION STDOUT'])
       expect(described_class.load(path).expected_application_stdout).not_to be_nil
     end

--- a/spec/modern_source_fixture_spec.rb
+++ b/spec/modern_source_fixture_spec.rb
@@ -35,6 +35,13 @@ describe DabModernSourceFixture do
     sections.map { |name, body| "## #{name}\n#{body}" }.join
   end
 
+  def with_application_stdout(sections, body:)
+    source = sections.fetch('SOURCE')
+    {'SOURCE' => source, 'EXPECTED APPLICATION STDOUT' => body}.merge(
+      sections.reject { |name| name == 'SOURCE' }
+    )
+  end
+
   it 'loads the committed versioned fixture with exact source and stream expectations' do
     fixture = described_class.load(committed_fixture)
 
@@ -42,6 +49,7 @@ describe DabModernSourceFixture do
     expect(fixture.source_filename).to eq('0001_unsupported_modern.dabm')
     expect(fixture.expected_status).to eq(2)
     expect(fixture.expected_stdout).to eq('')
+    expect(fixture.expected_application_stdout).to be_nil
     expect(fixture.expected_stderr).to eq(
       'compiler: 0001_unsupported_modern.dabm:1:0: error: ' \
       "unsupported Dab syntax profile \"modern\": parser is not implemented\n"
@@ -51,11 +59,11 @@ describe DabModernSourceFixture do
   it 'uses exact section bodies and treats absent stream sections as empty' do
     Dir.mktmpdir('dab-modern-source-fixture') do |directory|
       sections = {
-        'STATUS' => "0\n",
         'SOURCE' => "line one\nline two\n",
+        'EXPECTED APPLICATION STDOUT' => "application output\n\n",
         'SCHEMA VERSION' => "1\n",
+        'STATUS' => "0\n",
         'STDOUT' => "first line\nsecond line\n",
-        'APPLICATION STDOUT' => "application output\n",
       }
       fixture = described_class.load(write_fixture(directory, sections: sections))
 
@@ -65,6 +73,37 @@ describe DabModernSourceFixture do
       expect(fixture.expected_stderr).to eq('')
       expect(fixture.expected_application_stdout).to eq("application output\n")
     end
+  end
+
+  it 'loads the exact migrated runtime inventory with byte-exact output expectations' do
+    expected_basenames = %w[
+      0040_print_call_runtime.dabmtest
+      0041_string_length_calls.dabmtest
+      0046_print_member_argument.dabmtest
+      0047_multibyte_member_argument.dabmtest
+      0048_puts_member_argument.dabmtest
+      0054_print_zero_arity.dabmtest
+      0055_print_multiple_arity.dabmtest
+      0056_p01_helper_call.dabmtest
+      0059_fixed_local_bindings.dabmtest
+      0071_p02_bind_and_print_local.dabmtest
+      0072_mutable_local_reassignment.dabmtest
+    ]
+    paths = Dir[File.expand_path('../test/modern_source/*.dabmtest', __dir__)].select do |path|
+      File.binread(path).include?("## EXPECTED APPLICATION STDOUT\n")
+    end.sort
+
+    expect(paths.map { |path| File.basename(path) }).to eq(expected_basenames)
+    paths.each do |path|
+      headers = File.binread(path).scan(/^## ([A-Z]+(?: [A-Z]+)*)\n/).flatten
+      expect(headers.first(2)).to eq(['SOURCE', 'EXPECTED APPLICATION STDOUT'])
+      expect(described_class.load(path).expected_application_stdout).not_to be_nil
+    end
+
+    no_final_lf = described_class.load(paths.fetch(2)).expected_application_stdout
+    final_lf = described_class.load(paths.fetch(4)).expected_application_stdout
+    expect([no_final_lf, no_final_lf.bytes]).to eq(['3', [51]])
+    expect([final_lf, final_lf.bytes]).to eq(["3\n", [51, 10]])
   end
 
   it 'normalizes fixture transport CRLF while retaining exact section bodies' do
@@ -82,10 +121,18 @@ describe DabModernSourceFixture do
   end
 
   it 'rejects missing, duplicate, unknown, and wrongly named sections deterministically' do
+    runtime_sections = with_application_stdout(
+      valid_sections.merge('STATUS' => "0\n", 'STDOUT' => "assembly\n"),
+      body: "output\n"
+    )
     cases = {
       section_document(valid_sections.reject { |name| name == 'STATUS' }) => 'missing sections: STATUS',
       "#{section_document(valid_sections)}## STATUS\n2\n" => 'duplicate section: STATUS',
+      "#{section_document(runtime_sections)}## EXPECTED APPLICATION STDOUT\nother\n" =>
+        'duplicate section: EXPECTED APPLICATION STDOUT',
       section_document(valid_sections.merge('EXTRA' => "value\n")) => 'unsupported section: EXTRA',
+      section_document(runtime_sections).sub('## EXPECTED APPLICATION STDOUT', '## APPLICATION STDOUT') =>
+        'unsupported section: APPLICATION STDOUT',
       section_document(valid_sections).sub('## STATUS', '## status') => 'invalid section header: ## status',
       "preamble\n#{section_document(valid_sections)}" => 'content before first section',
     }
@@ -111,11 +158,14 @@ describe DabModernSourceFixture do
       valid_sections.merge('STATUS' => "256\n") => 'STATUS must be an Integer from 0 through 255',
       valid_sections.merge('STATUS' => "2\n\n") => 'STATUS must be an integer',
       valid_sections.merge('STDOUT' => '') => 'STDOUT must be omitted when its expected stream is empty',
-      valid_sections.merge('APPLICATION STDOUT' => '') =>
-        'APPLICATION STDOUT must be omitted when its expected stream is empty',
-      valid_sections.merge('APPLICATION STDOUT' => "output\n") => 'APPLICATION STDOUT requires STATUS 0',
-      valid_sections.merge('STATUS' => "0\n", 'APPLICATION STDOUT' => "output\n") =>
-        'APPLICATION STDOUT requires a STDOUT assembly expectation',
+      with_application_stdout(valid_sections, body: '') =>
+        'EXPECTED APPLICATION STDOUT must be omitted when its expected stream is empty',
+      with_application_stdout(valid_sections, body: "output\n") =>
+        'EXPECTED APPLICATION STDOUT requires STATUS 0',
+      with_application_stdout(valid_sections.merge('STATUS' => "0\n"), body: "output\n") =>
+        'EXPECTED APPLICATION STDOUT requires a STDOUT assembly expectation',
+      valid_sections.merge('EXPECTED APPLICATION STDOUT' => "misordered\n") =>
+        'EXPECTED APPLICATION STDOUT must immediately follow SOURCE',
     }
 
     Dir.mktmpdir('dab-modern-source-fixture') do |directory|

--- a/spec/modern_source_fixture_spec.rb
+++ b/spec/modern_source_fixture_spec.rb
@@ -89,8 +89,12 @@ describe DabModernSourceFixture do
       0071_p02_bind_and_print_local.dabmtest
       0072_mutable_local_reassignment.dabmtest
     ]
-    paths = Dir[File.expand_path('../test/modern_source/*.dabmtest', __dir__)].select do |path|
-      File.binread(path).include?("## EXPECTED APPLICATION STDOUT\n")
+    fixture_directory = File.expand_path('../test/modern_source', __dir__)
+    paths = Dir.children(fixture_directory).filter_map do |basename|
+      next unless basename.end_with?('.dabmtest')
+
+      path = File.join(fixture_directory, basename)
+      path if File.binread(path).include?("## EXPECTED APPLICATION STDOUT\n")
     end.sort
 
     expect(paths.map { |path| File.basename(path) }).to eq(expected_basenames)

--- a/src/frontend/frontend_modern_source.rb
+++ b/src/frontend/frontend_modern_source.rb
@@ -7,8 +7,9 @@ $autorun = true if $autorun.nil?
 class DabModernSourceFixture
   SCHEMA_VERSION = 1
   EXTENSION = '.dabmtest'.freeze
+  EXPECTED_APPLICATION_STDOUT_SECTION = 'EXPECTED APPLICATION STDOUT'.freeze
   REQUIRED_SECTIONS = ['SOURCE', 'SCHEMA VERSION', 'STATUS'].freeze
-  OPTIONAL_SECTIONS = ['STDOUT', 'STDERR', 'APPLICATION STDOUT'].freeze
+  OPTIONAL_SECTIONS = ['STDOUT', 'STDERR', EXPECTED_APPLICATION_STDOUT_SECTION].freeze
   SECTIONS = (REQUIRED_SECTIONS + OPTIONAL_SECTIONS).freeze
 
   class SchemaError < ArgumentError; end
@@ -34,7 +35,7 @@ class DabModernSourceFixture
     @expected_status = parse_status(sections.fetch('STATUS'))
     @expected_stdout = sections.fetch('STDOUT', '')
     @expected_stderr = sections.fetch('STDERR', '')
-    @expected_application_stdout = sections['APPLICATION STDOUT']
+    @expected_application_stdout = decode_application_stdout_expectation(sections)
     self
   rescue Errno::ENOENT, Errno::EACCES => e
     schema_error("fixture is not readable: #{e.message}")
@@ -63,6 +64,7 @@ private
     unknown = sections.keys - SECTIONS
     schema_error("missing sections: #{missing.join(', ')}") unless missing.empty?
     schema_error("unsupported section: #{unknown.join(', ')}") unless unknown.empty?
+    validate_application_stdout_order!(sections)
 
     schema_version = parse_integer('SCHEMA VERSION', sections.fetch('SCHEMA VERSION'))
     unless schema_version == SCHEMA_VERSION
@@ -70,15 +72,49 @@ private
     end
 
     OPTIONAL_SECTIONS.each do |name|
-      next unless sections.key?(name) && sections.fetch(name).empty?
+      next unless sections.key?(name)
+
+      body = if name == EXPECTED_APPLICATION_STDOUT_SECTION
+               parse_expected_application_stdout(sections.fetch(name))
+             else
+               sections.fetch(name)
+             end
+      next unless body.empty?
 
       schema_error("#{name} must be omitted when its expected stream is empty")
     end
 
-    return unless sections.key?('APPLICATION STDOUT')
+    return unless sections.key?(EXPECTED_APPLICATION_STDOUT_SECTION)
 
-    schema_error('APPLICATION STDOUT requires STATUS 0') unless parse_status(sections.fetch('STATUS')).zero?
-    schema_error('APPLICATION STDOUT requires a STDOUT assembly expectation') unless sections.key?('STDOUT')
+    unless parse_status(sections.fetch('STATUS')).zero?
+      schema_error("#{EXPECTED_APPLICATION_STDOUT_SECTION} requires STATUS 0")
+    end
+    unless sections.key?('STDOUT')
+      schema_error("#{EXPECTED_APPLICATION_STDOUT_SECTION} requires a STDOUT assembly expectation")
+    end
+  end
+
+  def validate_application_stdout_order!(sections)
+    output_index = sections.keys.index(EXPECTED_APPLICATION_STDOUT_SECTION)
+    return unless output_index
+    return if output_index == sections.keys.index('SOURCE') + 1
+
+    schema_error("#{EXPECTED_APPLICATION_STDOUT_SECTION} must immediately follow SOURCE")
+  end
+
+  def decode_application_stdout_expectation(sections)
+    encoded = sections[EXPECTED_APPLICATION_STDOUT_SECTION]
+    encoded && parse_expected_application_stdout(encoded)
+  end
+
+  def parse_expected_application_stdout(text)
+    return text if text.empty?
+
+    unless text.end_with?("\n")
+      schema_error("#{EXPECTED_APPLICATION_STDOUT_SECTION} must end with its section-separator LF")
+    end
+
+    text.delete_suffix("\n")
   end
 
   def parse_status(text)

--- a/test/modern_source/0040_print_call_runtime.dabmtest
+++ b/test/modern_source/0040_print_call_runtime.dabmtest
@@ -2,6 +2,9 @@
 def main
 print("R39 core\n")
 end
+## EXPECTED APPLICATION STDOUT
+R39 core
+
 ## SCHEMA VERSION
 1
 ## STATUS
@@ -62,5 +65,3 @@ end
                    _NDAT:
                                  W_BYTE 0 
  
-## APPLICATION STDOUT
-R39 core

--- a/test/modern_source/0041_string_length_calls.dabmtest
+++ b/test/modern_source/0041_string_length_calls.dabmtest
@@ -4,6 +4,9 @@ def main
 "xyz".length()
 print("R40 core\n")
 end
+## EXPECTED APPLICATION STDOUT
+R40 core
+
 ## SCHEMA VERSION
 1
 ## STATUS
@@ -70,5 +73,3 @@ end
                    _NDAT:
                                  W_BYTE 0 
  
-## APPLICATION STDOUT
-R40 core

--- a/test/modern_source/0046_print_member_argument.dabmtest
+++ b/test/modern_source/0046_print_member_argument.dabmtest
@@ -2,6 +2,8 @@
 def main
 print("abc".length)
 end
+## EXPECTED APPLICATION STDOUT
+3
 ## SCHEMA VERSION
 1
 ## STATUS
@@ -62,5 +64,3 @@ end
                    _NDAT:
                                  W_BYTE 0 
  
-## APPLICATION STDOUT
-3

--- a/test/modern_source/0047_multibyte_member_argument.dabmtest
+++ b/test/modern_source/0047_multibyte_member_argument.dabmtest
@@ -2,6 +2,8 @@
 def main
 print("é".length)
 end
+## EXPECTED APPLICATION STDOUT
+2
 ## SCHEMA VERSION
 1
 ## STATUS
@@ -62,5 +64,3 @@ end
                    _NDAT:
                                  W_BYTE 0 
  
-## APPLICATION STDOUT
-2

--- a/test/modern_source/0048_puts_member_argument.dabmtest
+++ b/test/modern_source/0048_puts_member_argument.dabmtest
@@ -2,6 +2,9 @@
 def main
 puts("abc".length)
 end
+## EXPECTED APPLICATION STDOUT
+3
+
 ## SCHEMA VERSION
 1
 ## STATUS
@@ -62,5 +65,3 @@ end
                    _NDAT:
                                  W_BYTE 0 
  
-## APPLICATION STDOUT
-3

--- a/test/modern_source/0054_print_zero_arity.dabmtest
+++ b/test/modern_source/0054_print_zero_arity.dabmtest
@@ -2,6 +2,9 @@
 def main
 print();print("after\n")
 end
+## EXPECTED APPLICATION STDOUT
+after
+
 ## SCHEMA VERSION
 1
 ## STATUS
@@ -62,5 +65,3 @@ end
                    _NDAT:
                                  W_BYTE 0 
  
-## APPLICATION STDOUT
-after

--- a/test/modern_source/0055_print_multiple_arity.dabmtest
+++ b/test/modern_source/0055_print_multiple_arity.dabmtest
@@ -2,6 +2,9 @@
 def main
 print(1, 2);print("\n")
 end
+## EXPECTED APPLICATION STDOUT
+12
+
 ## SCHEMA VERSION
 1
 ## STATUS
@@ -66,5 +69,3 @@ end
                    _NDAT:
                                  W_BYTE 0 
  
-## APPLICATION STDOUT
-12

--- a/test/modern_source/0056_p01_helper_call.dabmtest
+++ b/test/modern_source/0056_p01_helper_call.dabmtest
@@ -6,6 +6,9 @@ end
 def main()
   emit()
 end
+## EXPECTED APPLICATION STDOUT
+hello
+
 ## SCHEMA VERSION
 1
 ## STATUS
@@ -77,5 +80,3 @@ end
                    _NDAT:
                                  W_BYTE 0 
  
-## APPLICATION STDOUT
-hello

--- a/test/modern_source/0059_fixed_local_bindings.dabmtest
+++ b/test/modern_source/0059_fixed_local_bindings.dabmtest
@@ -9,6 +9,9 @@ def main()
   print(prefix)
   print(line)
 end
+## EXPECTED APPLICATION STDOUT
+fixed bindings
+
 ## SCHEMA VERSION
 1
 ## STATUS
@@ -88,5 +91,3 @@ end
                    _NDAT:
                                  W_BYTE 0 
  
-## APPLICATION STDOUT
-fixed bindings

--- a/test/modern_source/0071_p02_bind_and_print_local.dabmtest
+++ b/test/modern_source/0071_p02_bind_and_print_local.dabmtest
@@ -3,6 +3,9 @@ def main()
   let message = "hello\n"
   print(message)
 end
+## EXPECTED APPLICATION STDOUT
+hello
+
 ## SCHEMA VERSION
 1
 ## STATUS
@@ -63,5 +66,3 @@ end
                    _NDAT:
                                  W_BYTE 0 
  
-## APPLICATION STDOUT
-hello

--- a/test/modern_source/0072_mutable_local_reassignment.dabmtest
+++ b/test/modern_source/0072_mutable_local_reassignment.dabmtest
@@ -5,6 +5,10 @@ print(value)
 value = "second\n"
 print(value)
 end
+## EXPECTED APPLICATION STDOUT
+first
+second
+
 ## SCHEMA VERSION
 1
 ## STATUS
@@ -69,6 +73,3 @@ end
                    _NDAT:
                                  W_BYTE 0 
  
-## APPLICATION STDOUT
-first
-second

--- a/test/modern_source/README.md
+++ b/test/modern_source/README.md
@@ -3,9 +3,11 @@
 Files with the exact lowercase `.dabmtest` extension are versioned, single-source
 compiler fixtures owned by the `modern_source_spec` Rake task. Each file contains
 repository-native `## NAME` sections. The canonical order is required source,
-schema version, and status, followed by compiler stdout and stderr only when
-those exact expected streams are nonempty. A successful fixture may then add
-`APPLICATION STDOUT` to opt into assembly and native execution:
+an optional expected application stdout immediately after that complete source
+body, schema version, and status, followed by compiler stdout and stderr only
+when those exact expected streams are nonempty. A successful fixture may add
+`EXPECTED APPLICATION STDOUT` in that position to opt into assembly and native
+execution:
 
 ```text
 ## SOURCE
@@ -19,15 +21,16 @@ compiler diagnostic followed by a literal newline
 ```
 
 `SOURCE`, `SCHEMA VERSION`, and `STATUS` are required exactly once. `STDOUT`,
-`STDERR`, and `APPLICATION STDOUT` are optional, but an empty output section is
-invalid: omit it to expect an empty compiler stream or no application run.
-`APPLICATION STDOUT` requires status `0` and a `STDOUT` assembly expectation.
-The parser resolves sections by name, so input order does not change meaning,
-while committed fixtures use the canonical order above. The
-document must start with a section header. Headers are LF-terminated, begin in
-column zero, and use one of the exact uppercase names above; leading or trailing
-header whitespace, alternate spelling, duplicate sections, and unknown sections
-are schema failures.
+`STDERR`, and `EXPECTED APPLICATION STDOUT` are optional, but an empty output
+section is invalid: omit it to expect an empty compiler stream or no application
+run. `EXPECTED APPLICATION STDOUT` requires status `0`, a `STDOUT` assembly
+expectation, and placement immediately after `SOURCE`; the old `APPLICATION
+STDOUT` spelling is unsupported. The parser resolves all other sections by name,
+so their input order does not change meaning. The document must start with a
+section header. Headers are LF-terminated, begin in column zero, and use one of
+the exact uppercase names above; leading or trailing header whitespace,
+alternate spelling, duplicate sections, and unknown sections are schema
+failures.
 
 A section body starts immediately after its header LF and continues through the
 byte before the next column-zero `##` header or through end of file. Body bytes
@@ -41,11 +44,20 @@ integer from `0` through `255`; neither scalar accepts surrounding whitespace or
 extra blank lines. One final LF is permitted because it is the scalar section's
 owned line ending.
 
+`EXPECTED APPLICATION STDOUT` has one framing exception because required
+sections follow it and application output may end with or without LF. Exactly
+one physical LF immediately before the next section header is the section
+separator and is not part of the expected output. Therefore output without a
+final LF is written followed by one separator LF, while output with a final LF
+has an additional empty physical line before the next header. The reader removes
+only the separator LF, retaining every expected output byte exactly.
+
 CRLF used to transport the whole fixture is normalized to LF before section
 parsing, matching the original harness contract. Lone CR bytes remain body data.
-After that transport normalization, source, compiler streams, and application
-stdout bodies are retained exactly, so the same committed fixture has one source
-and expectation contract on Linux, macOS, and Windows.
+After that transport normalization and removal of the one application-output
+section separator LF, source, compiler streams, and decoded application stdout
+are retained exactly, so the same committed fixture has one source and
+expectation contract on Linux, macOS, and Windows.
 
 Some exact assembly expectations contain significant trailing spaces and a final
 blank line inherited from compiler stdout. The path-scoped `.gitattributes`
@@ -77,10 +89,10 @@ prove status `2`, empty standard output, exact standard error, stable
 fixture-derived filenames, and the shared-scanner location of the first
 mismatch. The Rake-owned suite supplies the separately compiled Legacy stdlib
 Ring so every fixture reaches the version-0.0.35 bootstrap boundary. Compiler
-results remain the default boundary. A fixture with `APPLICATION STDOUT`
-additionally assembles its already-matched compiler output, executes the native
-VM over that Ring, requires successful exit, and compares application output
-byte-for-byte.
+results remain the default boundary. A fixture with `EXPECTED APPLICATION
+STDOUT` additionally assembles its already-matched compiler output, executes the
+native VM over that Ring, requires successful exit, and compares application
+output byte-for-byte.
 
 Version 0.0.34 adds one multi-artifact exception that this single-source fixture
 schema cannot express: exactly one zero-byte file-backed Modern unit may compile


### PR DESCRIPTION
## Summary

Renames the Modern fixture runtime-output contract from `## APPLICATION STDOUT` to `## EXPECTED APPLICATION STDOUT` and moves it immediately after each complete `## SOURCE` block.

- migrates all 11 existing output-bearing `.dabmtest` fixtures
- updates the production fixture reader and focused schema/harness contracts
- rejects the old header through the existing unsupported-section boundary
- preserves every SOURCE byte, compiler stdout/assembly byte, and decoded application-output byte
- keeps root VERSION unchanged at `0.0.56`

## Exact refs and scope

- Base/master: `a81185da05e802c25643e72fa265723418bc3da0`
- Head: `f2940bd78795bef5f8545c181b575100c5f09cac`
- Branch: `tomasz/modern-fixture-expected-stdout`
- Scope: one commit, 14 paths
- VERSION: `0.0.56` unchanged

The migrated fixtures are 0040, 0041, 0046, 0047, 0048, 0054, 0055, 0056, 0059, 0071, and 0072. Post-migration inventory is exactly 11 new headers and zero old headers.

## Validation

- focused schema/harness RSpec: 14 examples, 0 failures
- Modern fixtures: 72/72 in normal and reverse order
- explicit verbose runtime-bearing inventory: all 11 passed compile, assemble, native execution, and byte-exact output comparison
- authoritative complete gate: PASSED, 528 examples, 0 failures, 16 established pending
- changed Ruby syntax: OK
- changed-file RuboCop: 2 files, 0 offenses
- `git diff --check`: clean
- generated documentation and final worker state: clean

Public-site and sanitizer reruns were not needed because no public-site or native path changed. The authoritative gate covered the inherited Legacy/shared harness and generated-documentation checks.

## Compatibility and limits

This intentionally replaces the old internal fixture header rather than retaining an alias. Fixture numbering, source text, compiler/assembler/runtime behavior, expected application-output bytes, language semantics, artifact trust boundary, and VERSION remain unchanged. No compiler language, bytecode, VM, stdlib, FFI, Ring, public-product, or roadmap work is included.
