### PR TITLE
Update json to 2.21.2 for GHSA-9hj4-r449-hfvc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     ffi (1.17.4-x86-linux-gnu)
     ffi (1.17.4-x86-linux-musl)
     ffi (1.17.4-x86_64-darwin)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.6)
     os (1.1.4)
     parallel (1.28.0)


### PR DESCRIPTION
## Security maintenance

This updates the root Ruby bundle from `json` 2.21.1 to 2.21.2, the first patched release for [GHSA-9hj4-r449-hfvc](https://github.com/ruby/json/security/advisories/GHSA-9hj4-r449-hfvc) / CVE-2026-71847 (low severity).

Exact base: `0dd6824bc522496d1ca875fb541cf2c95b7d0e5a`

Exact head: `212e733d3e31e2bfe564c55bf10810669d1b5b2d`

### Classification and scope

The root `Gemfile.lock` directly selected the affected native `json` 2.21.1 gem. Repository callers use ordinary `JSON.parse` and `JSON.generate`; no `JSON::ResumableParser` or `partial_value` caller was found, so repository application exploitability is not established. The supported root dependency graph was nevertheless concretely vulnerable and required remediation.

The patch changes only `Gemfile.lock` (`json` 2.21.1 to 2.21.2). `Gemfile`, `docs/Gemfile.lock`, `VERSION`, Wiki content, source, tests, workflows, and generated documentation are unchanged. `VERSION` remains 0.0.78.

### Security and compatibility evidence

Before the update, the upstream duplicate-key `partial_value` regression ran in a core-dump-disabled isolated Ruby 3.3.12 subprocess and exited 139. Its native stack reached `cursor_position`, `emit_parse_warning`, `emit_duplicate_key_warning`, `json_decode_object`, and `cResumableParser_partial_value_body` in `json` 2.21.1.

After the update:

- the exact upstream trigger completes without native termination on `json` 2.21.2;
- an alternate nested duplicate-key stream also completes;
- a legitimate `JSON.parse` / `JSON.generate` round trip passes;
- Bundler parses the root lock to exactly `json` 2.21.2 on every recorded platform;
- `bundle check` passes.

Removing the lockfile change restores the reproduced exit-139 failure.

### Validation

- Focused JSON-owning RSpec contracts: 105 examples, 0 failures.
- Supported-toolchain preflight: passed with Ruby 3.3.12, Bundler 2.7.2, and Premake 5.0.0-beta8.
- Authoritative `ruby script/complete_gate.rb`: passed.
  - Test manifest: 20 suites, 5 exceptions.
  - Inherited suites: minitest 5; Dab 241; Modern 104; format 32; VM 36; disasm 10; asm 102; dumpcov 2; cov 1; debug 7; multidab 12; decompile 24.
  - Full RSpec: 697 examples, 0 failures, 16 pending.
- `git diff --check`: passed.
- Generated documentation: unchanged.

Local proof covers Linux Ruby 3.3.12. Exact-head CI must still establish the supported Ruby 3.4.9 and 4.0.5 jobs, macOS, Windows, public-site, ASan, and UBSan coverage.

Dependabot alert #27 remains open, and the default branch remains affected, until this PR is merged. This PR does not dismiss or retry the alert and does not merge, release, deploy, tag, rebase, force-push, change repository settings, or alter OR-053.
